### PR TITLE
Fixing for an edge case in Mongrel 1.2.0.pre2

### DIFF
--- a/lib/rack/rewrite/rule.rb
+++ b/lib/rack/rewrite/rule.rb
@@ -182,7 +182,7 @@ module Rack
         
         # Construct the URL (without domain) from PATH_INFO and QUERY_STRING
         def build_path_from_env(env)
-          path = env['PATH_INFO']
+          path = env['PATH_INFO'] || ''
           path += "?#{env['QUERY_STRING']}" unless env['QUERY_STRING'].nil? || env['QUERY_STRING'].empty?
           path
         end

--- a/test/rule_test.rb
+++ b/test/rule_test.rb
@@ -371,6 +371,13 @@ class RuleTest < Test::Unit::TestCase
     end
   end
   
+  context 'Mongel 1.2.0.pre2 edge case: root url with a query string' do
+    should 'handle a nil PATH_INFO variable without errors' do
+      rule = Rack::Rewrite::Rule.new(:r301, '/a', '/')
+      assert_equal '?exists', rule.send(:build_path_from_env, {'QUERY_STRING' => 'exists'})
+    end
+  end
+  
   def rack_env_for(url, options = {})
     components = url.split('?')
     {'PATH_INFO' => components[0], 'QUERY_STRING' => components[1] || ''}.merge(options)


### PR DESCRIPTION
I ran into a problem with rack-rewrite blowing up when the `env['PATH_INFO']` variable was nil and the `env['QUERY_STRING']` variable was present. This happens under Mongrel 1.2.0.pre2 when hitting the root URL with a query string parameter. The `PATH_INFO` variable is not set and `Rack::Rewrite::Rule#build_path_from_env` blows up when trying to append to nil.

Small fix with a test, set to an empty string if `env['PATH_INFO']` is nil.
