### PR TITLE
Allow symbol matchers (to make README examples actually work)

### DIFF
--- a/lib/rack/rewrite/rule.rb
+++ b/lib/rack/rewrite/rule.rb
@@ -165,6 +165,8 @@ module Rack
             string =~ matcher
           elsif matcher.is_a?(String)
             string == matcher
+          elsif matcher.is_a?(Symbol)
+            string.downcase == matcher.to_s.downcase
           else
             false
           end


### PR DESCRIPTION
The :method examples stated in the README don't work because no matcher for symbols exists:

```
# redirect GET's one way
r301 "/players", "/current_players", :method => :get
```

This rule never matches because the method in rack_env is "GET", thus :get is not equal. This little patch accepts symbol matchers, converts both legs to string and downcases them. Symbol matchers therefore are case insensitive.
