### PR TITLE
I've added status option to send_file and x_send_file (rebased on current master)

### DIFF
--- a/lib/rack/rewrite/rule.rb
+++ b/lib/rack/rewrite/rule.rb
@@ -123,6 +123,7 @@ module Rack
             additional_headers = @options[:headers] || {}
           end
         end
+        status = @options[:status] || 200
         case self.rule_type
         when :r301
           [301, {'Location' => interpreted_to, 'Content-Type' => Rack::Mime.mime_type(::File.extname(interpreted_to))}.merge!(additional_headers), [redirect_message(interpreted_to)]]
@@ -144,12 +145,12 @@ module Rack
           end
           true
         when :send_file
-          [200, {
+          [status, {
             'Content-Length' => ::File.size(interpreted_to).to_s,
             'Content-Type'   => Rack::Mime.mime_type(::File.extname(interpreted_to))
             }.merge!(additional_headers), [::File.read(interpreted_to)]]
         when :x_send_file
-          [200, {
+          [status, {
             'X-Sendfile'     => interpreted_to,
             'Content-Length' => ::File.size(interpreted_to).to_s,
             'Content-Type'   => Rack::Mime.mime_type(::File.extname(interpreted_to))

--- a/test/rule_test.rb
+++ b/test/rule_test.rb
@@ -185,6 +185,16 @@ class RuleTest < Test::Unit::TestCase
         assert_equal [File.read(@file)], @response[2]
       end
     end
+
+    should 'return proper status for send_file or x_send_file if specified' do
+      [:send_file, :x_send_file].each do |rule_type|
+        file = File.join(TEST_ROOT, 'geminstaller.yml')
+        rule = Rack::Rewrite::Rule.new(rule_type, /.*/, file, :status => 503)
+        env = {'PATH_INFO' => '/abc'}
+        assert_equal 503, rule.apply!(env)[0]
+      end
+    end
+
   end
   
   context 'Rule#matches' do


### PR DESCRIPTION
Usage:

``` ruby
app.config.middleware.insert_before(Rack::Lock, Rack::Rewrite) do
  maintenance_file = Rails.root.join('public', 'maintenance.html').to_s
  send_file /(.*)$(?<!css|png|jpg)/, maintenance_file, :status => 503, :if => Proc.new{|rack_env|
    File.exists?(maintenance_file)
  }
end
```
