### PR TITLE
Added the ability to use external loaders

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -353,6 +353,33 @@ string to /today.html
   r301 lambda { "/#{Time.current.strftime(%m%d%Y)}.html" }, '/today.html'
 ```
 
+
+##Alternative loaders
+
+rack-rewrite can also be driven by external loaders. Bundled with this library is a loader for YAML files.
+
+```
+config.middleware.insert_before(Rack::Lock, Rack::Rewrite, 
+    :klass => Rack::Rewrite::YamlRuleSet, 
+    :options => {:file_name => @file_name})
+```
+
+Using syntax like
+
+```
+- 
+    method: r301
+    from: !ruby/regexp '/(.*)/print'
+    to : '$1/printer_friendly'
+    options : 
+        host : 'example.com'
+```
+
+Any class can be used here as long as: 
+  
+  - the class take an options hash
+  -  `#rules` returns an array of `Rack::Rewrite::Rule` instances
+
 ## Contribute
 
 rack-rewrite is maintained by [@travisjeffery](http://github.com/travisjeffery).

--- a/lib/rack/rewrite.rb
+++ b/lib/rack/rewrite.rb
@@ -5,9 +5,13 @@ module Rack
   # A rack middleware for defining and applying rewrite rules. In many cases you 
   # can get away with rack-rewrite instead of writing Apache mod_rewrite rules.  
   class Rewrite
-    def initialize(app, &rule_block)
+    def initialize(app, given_options = {}, &rule_block)
+      options = {
+          :klass => RuleSet,
+          :options => {}
+      }.merge(given_options)
       @app = app
-      @rule_set = RuleSet.new
+      @rule_set = options[:klass].new(options[:options])
       @rule_set.instance_eval(&rule_block) if block_given?
     end
     

--- a/lib/rack/rewrite/rule.rb
+++ b/lib/rack/rewrite/rule.rb
@@ -4,7 +4,7 @@ module Rack
   class Rewrite
     class RuleSet
       attr_reader :rules
-      def initialize #:nodoc:
+      def initialize(options = {})#:nodoc:
         @rules = []
       end
 

--- a/lib/rack/rewrite/yaml_rule_set.rb
+++ b/lib/rack/rewrite/yaml_rule_set.rb
@@ -1,0 +1,37 @@
+require 'rack/mime'
+require 'yaml'
+
+module Rack
+  class Rewrite
+    class YamlRuleSet
+
+      attr_reader :rules
+
+      #  Provides a method for setting the rewrite rules in a yaml file.
+      #  
+      #  Relys on Yaml to correctly produce ruby types like regex and then pushes
+      #  those values into a ruleset - giving the same result as if the DSL was 
+      #  used.
+
+      def initialize(options)
+        @options = options
+        @rules = generate_rules(load_rules)
+      end
+
+      def load_rules
+        YAML.load(::File.open(@options[:file_name]).read)
+      end
+
+      def generate_rules(yaml)
+        yaml.map do |rule|
+          options = rule["options"] || {}
+          options.keys.each do |key|
+            options[(key.to_sym rescue key) || key] = options.delete(key)
+          end
+          Rule.new(rule["method"].to_sym, rule["from"], rule["to"], options)
+        end
+      end
+
+    end
+  end
+end

--- a/test/rules.yml
+++ b/test/rules.yml
@@ -1,0 +1,16 @@
+- 
+    method: r301
+    from: '/abc'
+    to : '/def'
+- 
+    method: r301
+    from: !ruby/regexp '/(.*)/abc/'
+    to : '$1/regexed_path'
+- 
+    method: r301
+    from: '/withhost'
+    to : '/anotherhost'
+    options : 
+        host : 'example.com'
+
+

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,6 +8,11 @@ require 'test/unit'
 class Test::Unit::TestCase
 end
 
+def rack_env_for(url, options = {})
+  components = url.split('?')
+  {'PATH_INFO' => components[0], 'QUERY_STRING' => components[1] || ''}.merge(options)
+end
+
 def supported_status_codes
   [:r301, :r302, :r303, :r307]
 end

--- a/test/yaml_rule_set_test.rb
+++ b/test/yaml_rule_set_test.rb
@@ -1,0 +1,57 @@
+require 'test_helper'
+require 'lib/rack/rewrite/yaml_rule_set'
+
+
+class YamlRuleSetTest < Test::Unit::TestCase
+
+    TEST_ROOT = File.dirname(__FILE__)
+
+
+  context "When used through a rack app" do
+
+    setup do
+      @file_name = File.join(TEST_ROOT, 'rules.yml')
+      @app = Class.new { def call(app); true; end }.new
+    end
+
+    should 'be initialized when the app is created' do
+      Rack::Rewrite::YamlRuleSet.expects(:new).with(all_of({:file_name => @file_name}))
+      @rack = Rack::Rewrite.new(@app, 
+        :klass => Rack::Rewrite::YamlRuleSet, 
+        :options => {:file_name => @file_name}
+      )
+    end
+
+  end
+
+  context "When given some rules" do
+
+    setup do
+      @file_name = File.join(TEST_ROOT, 'rules.yml')
+      @rule_set =  Rack::Rewrite::YamlRuleSet.new(:file_name => @file_name)
+    end
+
+    should "correctly load up 3 rules" do
+      assert_equal 3, @rule_set.rules.length
+    end
+
+    should "correctly perform a regexed rule" do
+      env = rack_env_for("/something/abc")
+      rule = @rule_set.rules.detect{|a| a.matches?(env)}
+      assert_not_nil rule
+      assert_equal '/something/regexed_path', rule.apply!(env)[1]['Location']
+    end
+
+    should "correctly apply host option" do
+      env = rack_env_for("/withhost")
+      rule = @rule_set.rules.detect{|a| a.matches?(env)}
+      assert_nil rule
+
+      env = rack_env_for("/withhost", 'SERVER_NAME' => 'example.com', "SERVER_PORT" => "8080")
+      rule = @rule_set.rules.detect{|a| a.matches?(env)}
+      assert_not_nil rule
+      assert_equal '/anotherhost', rule.apply!(env)[1]['Location']
+    end
+
+  end
+end


### PR DESCRIPTION
Hi there,

So we were looking for a way to get rules loaded from our CMS into rack-rewrite. This patch allows the use of arbitrary rule set loaders if using the DSL isn't an option or if you want to load the rules from elsewhere.

I've also added a YAML rule set loader which might be useful since the redis one we're using would add gem dependencies. 
