### PR TITLE
add yaml_rule_set.rb to gemspec

### DIFF
--- a/rack-rewrite.gemspec
+++ b/rack-rewrite.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
     "lib/rack/rewrite.rb",
     "lib/rack/rewrite/rule.rb",
     "lib/rack/rewrite/version.rb",
+    "lib/rack/rewrite/yaml_rule_set.rb",
     "rack-rewrite.gemspec",
     "test/geminstaller.yml",
     "test/rack-rewrite_test.rb",


### PR DESCRIPTION
The YamlRuleSet file is missing in the latest gem (1.5.0) on rubygems.org.
