### PR TITLE
Fix duplicated key in apply!(env) method

### DIFF
--- a/lib/rack/rewrite/rule.rb
+++ b/lib/rack/rewrite/rule.rb
@@ -169,7 +169,7 @@ module Rack
             }.merge!(additional_headers), []]
         when :send_data
           [status, {
-            'Content-Type' => interpreted_to.bytesize,
+            'Content-Length' => interpreted_to.bytesize,
             'Content-Type' => 'text/html',
           }.merge!(additional_headers), [interpreted_to]]
         else


### PR DESCRIPTION
there is a typo in the :send_data case within the apply!(env) method of rule.rb, the key 'Content-Type' is used twice. should be 'Content-Length' on line 172. closes issue: https://github.com/jtrupiano/rack-rewrite/issues/65