### PR TITLE
Pattern matching fix

### DIFF
--- a/lib/rack/rewrite/rule.rb
+++ b/lib/rack/rewrite/rule.rb
@@ -226,7 +226,7 @@ module Rack
 
         def string_matches?(string, matcher)
           if self.is_a_regexp?(matcher)
-            string =~ matcher
+            (string =~ matcher) != nil
           elsif matcher.is_a?(String)
             string == matcher
           elsif matcher.is_a?(Symbol)

--- a/test/rule_test.rb
+++ b/test/rule_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class RuleTest < Test::Unit::TestCase
+class RuleTest < ZeroTest
 
   TEST_ROOT = File.dirname(__FILE__)
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,3 +16,16 @@ end
 def supported_status_codes
   [:r301, :r302, :r303, :r307]
 end
+
+class ZeroTest < Test::Unit::TestCase
+  def assert(test, msg= nil)
+    if test.class == Fixnum && test.zero?
+      super(false)
+    end
+    if msg.nil?
+      super(test)
+    else
+      super(test, msg)
+    end
+  end
+end


### PR DESCRIPTION
I have discovered that in some odd cases the rewrite will fail to occur despite the fact that it matched the pattern. I then discovered that sometimes `Rule#string_matches?` returns an Fixnum. This works just fine if the integer is not zero. If the integer is zero it causes Rule#matches to fail and the rewrite will not occur.

I wondered how this was missed in the test suite, and I further discovered that `assert(0)` comes back as true. I can think of no case where `assert(0)` succeeding would be a good idea. So I overrided assert in test_helper to have `assert(0)` fail. This revealed 14 failures which I then fixed. The only thing that might still need changing is the name of the class that inherits from Test::Unit::TestCase.