### PR TITLE
Add scheme test, test-unit to development dependencies

### DIFF
--- a/rack-rewrite.gemspec
+++ b/rack-rewrite.gemspec
@@ -48,6 +48,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'shoulda', '~> 2.10.2'
   s.add_development_dependency 'mocha', '~> 0.9.7'
   s.add_development_dependency 'rack'
+  s.add_development_dependency 'test-unit'
 
   if s.respond_to? :specification_version then
     s.specification_version = 3

--- a/test/rule_test.rb
+++ b/test/rule_test.rb
@@ -371,6 +371,19 @@ class RuleTest < Test::Unit::TestCase
       end
     end
 
+    context 'SSL redirect with scheme option' do
+      setup do
+        @rule = Rack::Rewrite::Rule.new(:r302, %r{.*}, 'https://www.mydomain.com$&', :scheme => 'http')
+      end
+
+      should 'work' do
+        env = {'PATH_INFO' => '/foo/bar', 'QUERY_STRING' => 'abc=1', 'SERVER_NAME' => 'mydomain.com', "rack.url_scheme" => "http"}
+        assert @rule.matches?(env)
+        rack_response = @rule.apply!(env)
+        assert_equal 'https://www.mydomain.com/foo/bar?abc=1', rack_response[1]['Location']
+      end
+    end
+
     context 'Given a lambda matcher' do
       setup do
         @rule = Rack::Rewrite::Rule.new(:r302, ->{ Thread.current[:test_matcher] }, '/today' )


### PR DESCRIPTION
I've seen that there're no specs for `scheme` option. This is useful having SSL redirects. 