### PR TITLE
Remove host from PATH_INFO

### DIFF
--- a/lib/rack/rewrite/rule.rb
+++ b/lib/rack/rewrite/rule.rb
@@ -148,17 +148,9 @@ module Rack
         when :rewrite
           # return [200, {}, {:content => env.inspect}]
           env['REQUEST_URI'] = interpreted_to
-          if q_index = interpreted_to.index('?')
-            env['QUERY_STRING'] = interpreted_to[q_index+1..interpreted_to.size-1]
-            if path_without_host = interpreted_to.match(/\/\/[^\/]+(\/[^?]*)/)
-              env['PATH_INFO'] = path_without_host[1]
-            else
-              env['PATH_INFO'] = interpreted_to[0..q_index-1]
-            end
-          else
-            env['PATH_INFO'] = interpreted_to
-            env['QUERY_STRING'] = ''
-          end
+          url_parts = interpreted_to.match(/(\/\/[^\/]+)?(\/[^?]*)(\?(.*))?/)
+          env['PATH_INFO'] = url_parts[2].to_s
+          env['QUERY_STRING'] = url_parts[4].to_s
           true
         when :send_file
           [status, {

--- a/lib/rack/rewrite/rule.rb
+++ b/lib/rack/rewrite/rule.rb
@@ -149,8 +149,12 @@ module Rack
           # return [200, {}, {:content => env.inspect}]
           env['REQUEST_URI'] = interpreted_to
           if q_index = interpreted_to.index('?')
-            env['PATH_INFO'] = interpreted_to[0..q_index-1]
             env['QUERY_STRING'] = interpreted_to[q_index+1..interpreted_to.size-1]
+            if path_without_host = interpreted_to.match(/\/\/[^\/]+(\/[^?]*)/)
+              env['PATH_INFO'] = path_without_host[1]
+            else
+              env['PATH_INFO'] = interpreted_to[0..q_index-1]
+            end
           else
             env['PATH_INFO'] = interpreted_to
             env['QUERY_STRING'] = ''

--- a/test/rule_test.rb
+++ b/test/rule_test.rb
@@ -65,6 +65,15 @@ class RuleTest < Test::Unit::TestCase
       assert_equal '/yair?show_bio=1', env['REQUEST_URI']
     end
 
+    should 'remove the host from PATH_INFO when rewriting the host' do
+      rule = Rack::Rewrite::Rule.new(:rewrite, %r{/(\w+)/(.*)}, "http://$1.test.com/$2")
+      env = {'PATH_INFO' => '/subdomain/path', 'QUERY_STRING' => 'param=1'}
+      rule.apply!(env)
+      assert_equal '/path', env['PATH_INFO']
+      assert_equal 'param=1', env['QUERY_STRING']
+      assert_equal 'http://subdomain.test.com/path?param=1', env['REQUEST_URI']
+    end
+
     should 'update the QUERY_STRING when a rewrite rule changes its value' do
       rule = Rack::Rewrite::Rule.new(:rewrite, %r{/(\w+)\?show_bio=(\d)}, '/$1?bio=$2')
       env = {'PATH_INFO' => '/john', 'QUERY_STRING' => 'show_bio=1'}


### PR DESCRIPTION
When a rewrite rule changes the host, the PATH_INFO should not include the host.

I am not so sure if my regexp catches all the possible scenarios.
