### PR TITLE
Adding MIT license to the gemspec.

### DIFF
--- a/rack-rewrite.gemspec
+++ b/rack-rewrite.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |s|
   s.date = Date.today.to_s
   s.description = %q{A rack middleware for enforcing rewrite rules. In many cases you can get away with rack-rewrite instead of writing Apache mod_rewrite rules.}
   s.email = %q{travisjeffery@gmail.com}
+  s.licenses = ["MIT"]
   s.extra_rdoc_files = [
     "LICENSE",
     "History.rdoc",


### PR DESCRIPTION
I'm working on [VersionEye](https://www.versioneye.com/) and my goal is to build up a license db for RubyGems which is complete. To reduce the manual work I'm doing currently it would be awesome if this gemspec would contain the license information in future. Many Thanks.