### PR TITLE
README: Make config.ru example runnable

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -23,6 +23,7 @@ use Rack::Rewrite do
   r302      '/wiki/Greg_Jastrab',   '/greg'
   r301      %r{/wiki/(\w+)_\w+},    '/$1'
 end
+run lambda { |env| [200, {'Content-Type' => 'text/plain'}, ['OK']] }
 ```
 
 ### Sample usage in a rails app


### PR DESCRIPTION
The sample rack file config.ru wasn't runnable because it lacked a rack app.

This adds a simple rack app so you can copy paste and rackup as intended.
