### PR TITLE
Suppress Ruby's deprecation using `File.exist?` instead of `File.exists?`

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -155,7 +155,7 @@ We can replace the mod_rewrite rules with the following Rack::Rewrite rule:
 ```ruby
 maintenance_file = File.join(RAILS_ROOT, 'public', 'system', 'maintenance.html')
 send_file /.*/, maintenance_file, :if => Proc.new { |rack_env|
-  File.exists?(maintenance_file) && rack_env['PATH_INFO'] !~ /\.(css|jpg|png)/
+  File.exist?(maintenance_file) && rack_env['PATH_INFO'] !~ /\.(css|jpg|png)/
 }
 ```
 
@@ -164,7 +164,7 @@ If you're running Ruby 1.9, this rule is simplified:
 ```ruby
 maintenance_file = File.join(RAILS_ROOT, 'public', 'system', 'maintenance.html')
 send_file /(.*)$(?<!css|png|jpg)/, maintenance_file, :if => Proc.new { |rack_env|
-  File.exists?(maintenance_file)
+  File.exist?(maintenance_file)
 }
 ```
 
@@ -174,7 +174,7 @@ get away with:
 ```ruby
 maintenance_file = File.join(RAILS_ROOT, 'public', 'system', 'maintenance.html')
 send_file Oniguruma::ORegexp.new("(.*)$(?<!css|png|jpg)"), maintenance_file, :if => Proc.new { |rack_env|
-  File.exists?(maintenance_file)
+  File.exist?(maintenance_file)
 }
 ```
 
@@ -229,10 +229,10 @@ send_file /*/, 'public/spammers.htm', :if => Proc.new { |rack_env|
   rack_env['HTTP_REFERER'] =~ 'spammers.com'
 }
 x_send_file /^blog\/.*/, 'public/blog_offline.htm', :if => Proc.new { |rack_env|
-  File.exists?('public/blog_offline.htm')
+  File.exist?('public/blog_offline.htm')
 }
 send_data /^blog\/.*/, 'public/blog_offline.png', :if => Proc.new { |rack_env|
-  File.exists?('public/blog_offline.htm')
+  File.exist?('public/blog_offline.htm')
 }
 ```
 
@@ -310,7 +310,7 @@ maintenance page on the filesystem can be utilized to take your site(s) offline.
 ```ruby
 maintenance_file = File.join(RAILS_ROOT, 'public', 'system', 'maintenance.html')
 x_send_file /.*/, maintenance_file, :if => Proc.new { |rack_env|
-  File.exists?(maintenance_file)
+  File.exist?(maintenance_file)
 }
 ```
 

--- a/lib/rack/rewrite/rule.rb
+++ b/lib/rack/rewrite/rule.rb
@@ -18,7 +18,7 @@ module Rack
         #
         #  rewrite '/wiki/John_Trupiano', '/john'
         #  rewrite %r{/wiki/(\w+)_\w+}, '/$1'
-        #  rewrite %r{(.*)}, '/maintenance.html', :if => lambda { File.exists?('maintenance.html') }
+        #  rewrite %r{(.*)}, '/maintenance.html', :if => lambda { File.exist?('maintenance.html') }
         def rewrite(*args)
           add_rule :rewrite, *args
         end
@@ -76,7 +76,7 @@ module Rack
         # Creates a rule that will render a file if matched.
         #
         #  send_file /*/, 'public/system/maintenance.html',
-        #    :if => Proc.new { File.exists?('public/system/maintenance.html') }
+        #    :if => Proc.new { File.exist?('public/system/maintenance.html') }
         def send_file(*args)
           add_rule :send_file, *args
         end
@@ -85,14 +85,14 @@ module Rack
         # if matched.
         #
         #  x_send_file /*/, 'public/system/maintenance.html',
-        #    :if => Proc.new { File.exists?('public/system/maintenance.html') }
+        #    :if => Proc.new { File.exist?('public/system/maintenance.html') }
         def x_send_file(*args)
           add_rule :x_send_file, *args
         end
 
         # Creates a rule taht will render the raw data if matched
         #  send_data /*/, 'public/system/maintenance.html',
-        #    :if => Proc.new { File.exists?('public/system/maintenance.html') }
+        #    :if => Proc.new { File.exist?('public/system/maintenance.html') }
         def send_data(*args)
           add_rule :send_data, *args
         end

--- a/test/rule_test.rb
+++ b/test/rule_test.rb
@@ -6,7 +6,7 @@ class RuleTest < Test::Unit::TestCase
 
   def self.should_pass_maintenance_tests
     context 'and the maintenance file does in fact exist' do
-      setup { File.stubs(:exists?).returns(true) }
+      setup { File.stubs(:exist?).returns(true) }
 
       should('match for the root')              { assert @rule.matches?(rack_env_for('/')) }
       should('match for a regular rails route') { assert @rule.matches?(rack_env_for('/users/1')) }
@@ -306,13 +306,13 @@ class RuleTest < Test::Unit::TestCase
     context 'Given a rule with a guard that checks for the presence of a file' do
       setup do
         @rule = Rack::Rewrite::Rule.new(:rewrite, %r{(.)*}, '/maintenance.html', lambda { |rack_env|
-          File.exists?('maintenance.html')
+          File.exist?('maintenance.html')
         })
       end
 
       context 'when the file exists' do
         setup do
-          File.stubs(:exists?).returns(true)
+          File.stubs(:exist?).returns(true)
         end
 
         should 'match' do
@@ -322,7 +322,7 @@ class RuleTest < Test::Unit::TestCase
 
       context 'when the file does not exist' do
         setup do
-          File.stubs(:exists?).returns(false)
+          File.stubs(:exist?).returns(false)
         end
 
         should 'not match' do
@@ -335,7 +335,7 @@ class RuleTest < Test::Unit::TestCase
       setup do
         @rule = Rack::Rewrite::Rule.new(:rewrite, /.*/, '/system/maintenance.html', lambda { |rack_env|
           maintenance_file = File.join('system', 'maintenance.html')
-          File.exists?(maintenance_file) && rack_env['PATH_INFO'] !~ /\.(css|jpg|png)/
+          File.exist?(maintenance_file) && rack_env['PATH_INFO'] !~ /\.(css|jpg|png)/
         })
       end
       should_pass_maintenance_tests
@@ -345,7 +345,7 @@ class RuleTest < Test::Unit::TestCase
       context 'Given the negative lookahead regular expression version of the capistrano maintenance.html rewrite rule given in our README' do
         setup do
           @rule = Rack::Rewrite::Rule.new(:rewrite, negative_lookahead_regexp, '/system/maintenance.html', lambda { |rack_env|
-            File.exists?(File.join('public', 'system', 'maintenance.html'))
+            File.exist?(File.join('public', 'system', 'maintenance.html'))
           })
         end
         should_pass_maintenance_tests


### PR DESCRIPTION
The latter is deprecated since Ruby 2.1.0.
ref: http://docs.ruby-lang.org/en/2.2.0/File.html#method-c-exists-3F

And `File.exist?` works fine for older Ruby versions.
