### PR TITLE
Fix test for Ruby 2.3.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,5 @@ gemspec
 group :development do
   gem 'rake'
 end
+
+gem 'test-unit' if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.3')


### PR DESCRIPTION
In Ruby 2.3, test-unit is removed from bundled gems.
ref: https://bugs.ruby-lang.org/issues/9711
